### PR TITLE
enabled readv 

### DIFF
--- a/src/Factory.hh
+++ b/src/Factory.hh
@@ -43,6 +43,7 @@ public:
     std::string &GetTempDirectory() {return m_temp_directory;}
     XrdOss* &GetOss() {return m_output_fs;}
 
+    void CheckDirStatRecurse( XrdOssDF* df, std::string& path);
     static Factory &GetInstance();
 
 protected:

--- a/src/IO.hh
+++ b/src/IO.hh
@@ -16,6 +16,7 @@
 
 #include "XrdFileCacheFwd.hh"
 
+#define HAVE_READV
 class XrdSysError;
 
 namespace XrdFileCache {


### PR DESCRIPTION
Changes since the last pool request:
- enable vector read
- used cached files if Prefecth has sucessfully finished
- clean temporary dir using XrdOss tools
